### PR TITLE
Fixed issue #5

### DIFF
--- a/lib/recorder/index.js
+++ b/lib/recorder/index.js
@@ -82,24 +82,10 @@ Recorder.prototype = {
     
     async.series([
       function saveMetaData( next ) {
-        fs.stat( metafile, function( error, stats ) {
-          // Error, proceed with failure
-          if( error && error.errno !== -2 ) return next( error )
-          // File with the same properties already exists
-          if( stats && stats.isFile() ) return next()
-          // File doesn't exist yet, write it to disk
-          fs.writeFile( metafile, JSON.stringify( metadata, null, 2 ), next )
-        })
+        fs.writeFile( metafile, JSON.stringify( metadata, null, 2 ), { flag: 'wx' }, next )
       },
       function saveBody( next ) {
-        fs.stat( bodyfile, function( error, stats ) {
-          // Error, proceed with failure
-          if( error && error.errno !== -2 ) return next( error )
-          // File with the same properties already exists
-          if( stats && stats.isFile() ) return next()
-          // File doesn't exist yet, write it to disk
-          fs.writeFile( bodyfile, self.response.buffer, next )
-        })
+        fs.writeFile( bodyfile, self.response.buffer, { flag: 'wx' }, next )
       },
     ], function done( error, results ) {
       if( error != null ) {


### PR DESCRIPTION
I believe this fixes issue #5.

The problem is that stat returns error -34 on my platform (and ENOENT), but using stat is overkill in the first place. If the file is just opened for exclusive writing (`flag: 'wx'`), `writeFile` will die if the file exists.

This makes the code significantly shorter and more readable. Note that The previous line `if( stats && stats.isFile() ) return next()` meant that if there was something at the path in question which *isn't* a file, the old version would try to overwrite it. I consider that an error state to be avoided.
