### PR TITLE
Fix failing tests (socket unlink)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
 language: node_js
 node_js:
+  - "3"
+  - "2"
+  - "1"
+  - "0.12"
   - "0.10"
 branches:
   only:
     - master
+sudo: false
 script: npm test

--- a/lib/irrlicht.js
+++ b/lib/irrlicht.js
@@ -93,10 +93,7 @@ function Irrlicht( options ) {
     mkdirp.sync( Path.join( this.path, 'data' ) )
   }
   
-  // TODO: Handle this more robustly
-  process.on( 'exit', function() {
-    fs.unlinkSync( this.socket )
-  }.bind( this ))
+  process.on( 'exit', this.close.bind( this ) )
   
 }
 
@@ -646,7 +643,6 @@ Irrlicht.prototype = {
   close: function( callback ) {
     
     debug( 'CLOSE' )
-    this.emit( 'close' )
     
     var self = this
     var done = typeof callback === 'function' ?
@@ -655,7 +651,10 @@ Irrlicht.prototype = {
     async.series([
       function( next ) { self.http.close( next ) },
       function( next ) { self.https.close( next ) },
-    ], done )
+    ], function( error ) {
+      this.emit( 'close', error )
+      done( error )
+    })
     
     return this
     


### PR DESCRIPTION
- Enabled Travis CI
- Updated node / io versions to be tested by Travis
- Fixed error unlinking the socket on process.exit when it wasn't used